### PR TITLE
This is a bug fix for issue #6 - Persistence Exception - arrivalDeadl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.2.3</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
@@ -135,6 +135,8 @@
             </plugin>
         </plugins>
     </build>
+
+
 
     <profiles>
         <!-- GlassFish specific version of build -->

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The simplest steps are the following (no IDE required):
 
 To set up in NetBeans, follow these steps:
 
-* Set up JDK 8+, NetBeans 8.2+ and Payara 5+.
+* Set up JDK 12, NetBeans 11.1 and Payara 5 (5.193 or newer).
 * Open the source code directory in NetBeans - it's just a Maven project, NetBeans will do the rest for you. As noted in the site instructions on NetBeans, you may get a few spurious errors due to reported NetBeans bugs. Just ignore them and proceed with clean/building the application.
 * After the project is built (which will take a while the very first time as Maven downloads dependencies), simply run it via Payara 5.
   

--- a/src/main/java/net/java/cargotracker/domain/model/cargo/Delivery.java
+++ b/src/main/java/net/java/cargotracker/domain/model/cargo/Delivery.java
@@ -3,6 +3,8 @@ package net.java.cargotracker.domain.model.cargo;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Iterator;
 import javax.persistence.Column;
@@ -60,7 +62,7 @@ public class Delivery implements Serializable {
     private RoutingStatus routingStatus;
     @Column(name = "calculated_at")
     @NotNull
-    private LocalDateTime calculatedAt;
+    private OffsetDateTime calculatedAt;
     @ManyToOne
     @JoinColumn(name = "last_event_id")
     private HandlingEvent lastEvent;
@@ -71,7 +73,7 @@ public class Delivery implements Serializable {
 
     public Delivery(HandlingEvent lastEvent, Itinerary itinerary,
             RouteSpecification routeSpecification) {
-        this.calculatedAt = LocalDateTime.now();
+        this.calculatedAt = OffsetDateTime.now();
         this.lastEvent = lastEvent;
 
         this.misdirected = calculateMisdirectionStatus(itinerary);
@@ -197,11 +199,11 @@ public class Delivery implements Serializable {
      * @return When this delivery was calculated.
      */
     public LocalDateTime getCalculatedAt() {
-        return calculatedAt;
+        return calculatedAt.toLocalDateTime();
     }
 
     public void setCalculatedAt(LocalDateTime calculatedAt) {
-        this.calculatedAt = calculatedAt;
+        this.calculatedAt = calculatedAt.atOffset(ZoneOffset.UTC);
     }
 
     private TransportStatus calculateTransportStatus() {

--- a/src/main/java/net/java/cargotracker/domain/model/cargo/RouteSpecification.java
+++ b/src/main/java/net/java/cargotracker/domain/model/cargo/RouteSpecification.java
@@ -6,8 +6,6 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 import net.java.cargotracker.domain.model.location.Location;
 import net.java.cargotracker.domain.shared.AbstractSpecification;
@@ -30,7 +28,7 @@ public class RouteSpecification extends AbstractSpecification<Itinerary>
     @ManyToOne
     @JoinColumn(name = "spec_destination_id")
     private Location destination;
-    @Temporal(TemporalType.DATE)
+
     @Column(name = "spec_arrival_deadline")
     @NotNull
     private LocalDate arrivalDeadline;

--- a/src/main/java/net/java/cargotracker/domain/model/handling/HandlingEvent.java
+++ b/src/main/java/net/java/cargotracker/domain/model/handling/HandlingEvent.java
@@ -1,7 +1,12 @@
 package net.java.cargotracker.domain.model.handling;
 
-import java.io.Serializable;
-import java.util.Date;
+import net.java.cargotracker.domain.model.cargo.Cargo;
+import net.java.cargotracker.domain.model.location.Location;
+import net.java.cargotracker.domain.model.voyage.Voyage;
+import net.java.cargotracker.domain.shared.DomainObjectUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,19 +17,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQuery;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
-
-import net.java.cargotracker.domain.model.cargo.Cargo;
-import net.java.cargotracker.domain.model.location.Location;
-import net.java.cargotracker.domain.model.voyage.Voyage;
-import net.java.cargotracker.domain.shared.DomainObjectUtils;
-
-import org.apache.commons.lang3.Validate;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.io.Serializable;
+import java.util.Date;
 
 /**
  * A HandlingEvent is used to register the event when, for instance, a cargo is
@@ -64,11 +60,9 @@ public class HandlingEvent implements Serializable {
     @JoinColumn(name = "location_id")
     @NotNull
     private Location location;
-    @Temporal(TemporalType.DATE)
     @NotNull
     @Column(name = "completionTime")
     private Date completionTime;
-    @Temporal(TemporalType.DATE)
     @NotNull
     @Column(name = "registration")
     private Date registrationTime;

--- a/src/main/java/net/java/cargotracker/domain/model/voyage/CarrierMovement.java
+++ b/src/main/java/net/java/cargotracker/domain/model/voyage/CarrierMovement.java
@@ -1,7 +1,10 @@
 package net.java.cargotracker.domain.model.voyage;
 
-import java.io.Serializable;
-import java.util.Date;
+import net.java.cargotracker.domain.model.location.Location;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -9,13 +12,9 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
-import net.java.cargotracker.domain.model.location.Location;
-import org.apache.commons.lang3.Validate;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.io.Serializable;
+import java.util.Date;
 
 /**
  * A carrier movement is a vessel voyage from one location to another.
@@ -36,11 +35,11 @@ public class CarrierMovement implements Serializable {
     @JoinColumn(name = "arrival_location_id")
     @NotNull
     private Location arrivalLocation;
-    @Temporal(TemporalType.TIMESTAMP)
+
     @Column(name = "departure_time")
     @NotNull
     private Date departureTime;
-    @Temporal(TemporalType.TIMESTAMP)
+
     @Column(name = "arrival_time")
     @NotNull
     private Date arrivalTime;

--- a/src/main/java/net/java/cargotracker/interfaces/booking/facade/dto/CargoRoute.java
+++ b/src/main/java/net/java/cargotracker/interfaces/booking/facade/dto/CargoRoute.java
@@ -1,8 +1,10 @@
 package net.java.cargotracker.interfaces.booking.facade.dto;
 
 import java.io.Serializable;
+import java.sql.Date;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,7 +18,7 @@ public class CargoRoute implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private static final SimpleDateFormat DATE_FORMAT
-            = new SimpleDateFormat("MM/dd/yyyy hh:mm a z");
+            = new SimpleDateFormat("yyyy-MM-dd");
 
     private final String trackingId;
     private final String origin;
@@ -30,12 +32,12 @@ public class CargoRoute implements Serializable {
     private String nextLocation;
 
     public CargoRoute(String trackingId, String origin, String finalDestination,
-            LocalDate arrivalDeadline, boolean misrouted, boolean claimed, 
-            String lastKnownLocation, String transportStatus) {
+                      LocalDate arrivalDeadline, boolean misrouted, boolean claimed,
+                      String lastKnownLocation, String transportStatus) {
         this.trackingId = trackingId;
         this.origin = origin;
         this.finalDestination = finalDestination;
-        this.arrivalDeadline = DATE_FORMAT.format(arrivalDeadline);
+        this.arrivalDeadline = DATE_FORMAT.format(Date.valueOf(arrivalDeadline));
         this.misrouted = misrouted;
         this.claimed = claimed;
         this.lastKnownLocation = lastKnownLocation;
@@ -99,11 +101,11 @@ public class CargoRoute implements Serializable {
     }
     
     public String getArrivalDeadlineDate() {
-        return DateUtil.getDateFromDateTime(arrivalDeadline); 
+        return arrivalDeadline;
     }
 
     public String getArrivalDeadlineTime() {
-        return DateUtil.getTimeFromDateTime(arrivalDeadline);
+        return arrivalDeadline; // TODO fix, should have the time.
     }
 
     public boolean isClaimed() {

--- a/src/main/java/net/java/cargotracker/interfaces/booking/facade/dto/Leg.java
+++ b/src/main/java/net/java/cargotracker/interfaces/booking/facade/dto/Leg.java
@@ -34,8 +34,8 @@ public class Leg implements Serializable {
         this.fromName = fromName;
         this.toUnLocode = toUnLocode;
         this.toName = toName;
-        this.loadTime = DATE_FORMAT.format(loadTime);
-        this.unloadTime = DATE_FORMAT.format(unloadTime);
+        this.loadTime = DATE_FORMAT.format(DateUtil.toDate(loadTime));
+        this.unloadTime = DATE_FORMAT.format(DateUtil.toDate(unloadTime));
     }
 
     public String getVoyageNumber() {
@@ -71,11 +71,11 @@ public class Leg implements Serializable {
     }
 
     public String getLoadTimeDate() {
-        return DateUtil.getDateFromDateTime(loadTime);
+        return loadTime;
     }
 
     public String getLoadTimeTime() {
-        return DateUtil.getTimeFromDateTime(loadTime);
+        return loadTime;
     }
 
     public String getUnloadTime() {
@@ -83,11 +83,11 @@ public class Leg implements Serializable {
     }
 
     public String getUnloadTimeTime() {
-        return DateUtil.getTimeFromDateTime(unloadTime);
+        return unloadTime;
     }
 
     public String getUnloadTimeDate() {
-        return DateUtil.getDateFromDateTime(unloadTime);
+        return unloadTime;
     }
 
     @Override

--- a/src/main/java/net/java/cargotracker/interfaces/tracking/web/CargoTrackingViewAdapter.java
+++ b/src/main/java/net/java/cargotracker/interfaces/tracking/web/CargoTrackingViewAdapter.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import static net.java.cargotracker.application.util.LocationUtil.getCoordinatesForLocation;
+
+import net.java.cargotracker.application.util.DateUtil;
 import net.java.cargotracker.domain.model.cargo.Cargo;
 import net.java.cargotracker.domain.model.cargo.Delivery;
 import net.java.cargotracker.domain.model.cargo.HandlingActivity;
@@ -90,7 +92,7 @@ public class CargoTrackingViewAdapter {
         if (eta == null) {
             return "?";
         } else {
-            return DATE_FORMAT.format(eta);
+            return DATE_FORMAT.format(DateUtil.toDate(eta));
         }
     }
 

--- a/src/main/java/net/java/pathfinder/api/GraphTraversalService.java
+++ b/src/main/java/net/java/pathfinder/api/GraphTraversalService.java
@@ -1,8 +1,7 @@
 package net.java.pathfinder.api;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.*;
+import net.java.pathfinder.internal.GraphDao;
+
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
@@ -11,7 +10,11 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import net.java.pathfinder.internal.GraphDao;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 @Stateless
 @Path("/graph-traversal")

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <persistence
-    version="2.1"
+    version="2.2"
     xmlns="http://xmlns.jcp.org/xml/ns/persistence"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
-    <persistence-unit name="CargoTrackerUnit">
-        <jta-data-source>java:app/jdbc/CargoTrackerDatabase</jta-data-source>
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+    <persistence-unit name="CargoTrackerUnit" transaction-type="JTA">
+        <jta-data-source>jdbc/cargo-tracker</jta-data-source>
         <properties>
             <!-- The default behavior is not generating a schema.
             Schema generation is good for demos, RAD, development, etc but likely
@@ -16,4 +16,5 @@
             <property name="eclipselink.logging.level" value="FINEST"/>
         </properties>
     </persistence-unit>
+
 </persistence>

--- a/src/main/webapp/WEB-INF/templates/common/public.xhtml
+++ b/src/main/webapp/WEB-INF/templates/common/public.xhtml
@@ -21,7 +21,7 @@
                         <div class="ui-grid-col-7" >
                             <a href="#{request.contextPath}" style="text-decoration: none;color:white;">
                                 &#160;&#160;<img src="../images/CTlogobadge128.png" style="padding-top: 10px;" height="30"/>&#160;&#160;&#160;
-                                <h:outputText styleClass="titleText" value="Cargo Tracker - Powered by Java EE 7" />
+                                <h:outputText styleClass="titleText" value="Cargo Tracker - Powered by Jakarta EE 8" />
                             </a></div>
                         <div class="ui-grid-col-2"></div>
                         <div class="ui-grid-col-1" style="padding-top: 24px;">

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.1"
+<web-app version="4.0"
          xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee  http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
 
     <!-- Overriding system level defaults is a decent usage of XML -->
     <context-param>


### PR DESCRIPTION
…ine datatype - EclipseLink

Regarding this temporary fix:
- Java 12 is required as there is a bug on Java 8 DateFormat parse which doesn't fails on TimeZone.
- Switched the database over to using Postgresql. The embedded database doesn't fully support conversion with the time API introduced in Java 8.
- This is not a complete fix as some reworking of the Java 8 types still needs to be done. Some of the places using LocalDate should be using LocalDateTime as the time information is now missing.
- Also upgraded the Maven plugins so CargoTracker could be build on Java 12.